### PR TITLE
Save/restore element style rather than individual CSS attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # jQuery Actual Plugin CHANGELOG
 
+## 1.0.7
+
+Save/restore element style rather than individual CSS attributes. It is much faster on restore,
+as well as more correct. Restoring CSS attributes will create element style where none originally
+existed.
+
 ## 1.0.6
 
 * [bug fixed] Pass `configs.includeMargin` to only `outerWidth` and `outerHeight` so it does not break in $ 1.7.2

--- a/jquery.actual.js
+++ b/jquery.actual.js
@@ -1,4 +1,4 @@
-/*! Copyright 2011, Ben Lin (http://dreamerslab.com/)
+/* Copyright 2011, Ben Lin (http://dreamerslab.com/)
 * Licensed under the MIT License (LICENSE.txt).
 *
 * Version: 1.0.6
@@ -36,7 +36,7 @@
           // remove DOM element after getting the width
           $target.remove();
         };
-      }else{
+      }else {
         fix = function(){
           // get all hidden parents
           $hidden = $target.parents().andSelf().filter( ':hidden' );
@@ -47,29 +47,24 @@
 
           tmp = [];
 
-          // save the origin style props
-          // set the hidden el css to be got the actual value later
-          $hidden.each( function(){
-            var _tmp = {}, name;
-            for( name in css ){
-              // save current style
-              _tmp[ name ] = this.style[ name ];
-              // set current style to proper css style
-              this.style[ name ] = css[ name ];
-            }
-            tmp.push( _tmp );
+          // save the original style
+          $hidden.each( function() {
+           var $this = $(this);
+             // Save original style. If no style was set, attr() returns undefined
+             tmp.push( $this.attr("style") );
+             $this.css(css);
           });
         };
 
         restore = function(){
-          // restore origin style values
-          $hidden.each( function( i ){
-            var _tmp = tmp[ i ], name;
-            for( name in css ){
-              this.style[ name ] = _tmp[ name ];
-            }
+          // restore original style values
+          $hidden.each( function( i ) {
+            var $this = $(this), _tmp = tmp[ i ];
+            if (_tmp === undefined) { $this.removeAttr("style"); }
+            else                    { $this.attr("style", _tmp); }
           });
         };
+
       }
 
       fix();

--- a/jquery.actual.min.js
+++ b/jquery.actual.min.js
@@ -1,8 +1,8 @@
 /* Copyright 2011, Ben Lin (http://dreamerslab.com/)
 * Licensed under the MIT License (LICENSE.txt).
 *
-* Version: 1.0.6
+* Version: 1.0.7
 *
 * Requires: jQuery 1.2.3 ~ 1.7.1
 */
-;(function(a){a.fn.extend({actual:function(b,k){var c,d,h,g,f,j,e,i;if(!this[b]){throw'$.actual => The jQuery method "'+b+'" you called does not exist';}h=a.extend({absolute:false,clone:false,includeMargin:undefined},k);d=this;if(h.clone===true){e=function(){d=d.filter(":first").clone().css({position:"absolute",top:-1000}).appendTo("body");};i=function(){d.remove();};}else{e=function(){c=d.parents().andSelf().filter(":hidden");g=h.absolute===true?{position:"absolute",visibility:"hidden",display:"block"}:{visibility:"hidden",display:"block"};f=[];c.each(function(){var m={},l;for(l in g){m[l]=this.style[l];this.style[l]=g[l];}f.push(m);});};i=function(){c.each(function(m){var n=f[m],l;for(l in g){this.style[l]=n[l];}});};}e();j=/(outer)/g.test(b)?d[b](h.includeMargin):d[b]();i();return j;}});})(jQuery);
+(function(a){a.fn.extend({actual:function(b,k){var c,d,h,g,f,j,e,i;if(!this[b]){throw'$.actual => The jQuery method "'+b+'" you called does not exist'}h=a.extend({absolute:false,clone:false,includeMargin:undefined},k);d=this;if(h.clone===true){e=function(){d=d.filter(":first").clone().css({position:"absolute",top:-1000}).appendTo("body")};i=function(){d.remove()}}else{e=function(){c=d.parents().andSelf().filter(":hidden");g=h.absolute===true?{position:"absolute",visibility:"hidden",display:"block"}:{visibility:"hidden",display:"block"};f=[];c.each(function(){var l=a(this);f.push(l.attr("style"));l.css(g)})};i=function(){c.each(function(l){var n=a(this),m=f[l];if(m===undefined){n.removeAttr("style")}else{n.attr("style",m)}})}}e();j=/(outer)/g.test(b)?d[b](h.includeMargin):d[b]();i();return j}})})(jQuery);


### PR DESCRIPTION
Modified to save/restore element style, rather than individual CSS
attributes. It is much faster to restore the element style than to
set the CSS attributes. As well, it is more correct: retrieving CSS
attributes does so whether the element actually has a style or not.
(e.g. it will obtain the attribute from the CSS cascade.) Upon restore,
if the element didn't originally have a style, now it does! Instead,
we save the element style, if it has one, then modify the CSS attributes
as needed to get the dimensions. If the element didn't originally
have a style, the style is then simply removed. If it did originally
have a style, restore the original style.
