### PR TITLE
Attempt to add support for jQuery 1.9.0 (needs testing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jQuery Actual Plugin CHANGELOG
 
+## 1.0.14
+
+- Added support for jQuery 1.9.0
+
 ## 1.0.13
 
 - [bug fix] Local variable `style` not initialized, thanks to [Searle](https://github.com/Searle)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jQuery has trouble finding the width/height of invisible DOM elements. With elem
 
 ## Requires
 
-- jQuery 1.2.3 ~ 1.8.0
+- jQuery 1.2.3 ~ 1.9.0
 
 
 
@@ -97,6 +97,7 @@ Example code:
 - [Jon Tara](https://github.com/jtara)
 - [Matt Hinchliffe](https://github.com/i-like-robots)
 - [Ryan Millikin](https://github.com/dhamma)
+- [Jacob Quant](https://github.com/jacobq)
 
 
 

--- a/demo/css3pie.html
+++ b/demo/css3pie.html
@@ -131,7 +131,10 @@
     <script type="text/javascript" src="../jquery.actual.min.js"></script>    
     <script type="text/javascript" charset="utf-8">
 
-      if( $.browser.msie && $.browser.version < 7 ){
+      // Should be equivalent to: if( $.browser.msie && $.browser.version < 7 ){
+      if( navigator.appName === "Microsoft Internet Explorer" &&
+          parseFloat(navigator.userAgent.replace(new RegExp(".*MSIE\\D*(\\d+.\\d+).*"), "$1")) < 7
+      ){        
         $( function(){  
           $( '#with-jquery-width' ).find( 'a' ).each( function(){
             var $this = $( this );

--- a/jquery.actual.js
+++ b/jquery.actual.js
@@ -1,9 +1,9 @@
 /*! Copyright 2012, Ben Lin (http://dreamerslab.com/)
  * Licensed under the MIT License (LICENSE.txt).
  *
- * Version: 1.0.13
+ * Version: 1.0.14
  *
- * Requires: jQuery 1.2.3 ~ 1.8.2
+ * Requires: jQuery 1.2.3 ~ 1.9.0
  */
 ;( function ( $ ){
   $.fn.extend({
@@ -46,10 +46,10 @@
 
         fix = function (){
           // get all hidden parents
-          $hidden = $target.
-            parents().
-            andSelf().
-            filter( ':hidden' );
+          if ($.fn.jquery >= "1.8.0")
+            $hidden = $target.parents().addBack().filter( ':hidden' );
+          else
+            $hidden = $target.parents().andSelf().filter( ':hidden' );
 
           style += 'visibility: hidden !important; display: block !important; ';
 

--- a/jquery.actual.min.js
+++ b/jquery.actual.min.js
@@ -1,8 +1,8 @@
 /*! Copyright 2012, Ben Lin (http://dreamerslab.com/)
  * Licensed under the MIT License (LICENSE.txt).
  *
- * Version: 1.0.13
+ * Version: 1.0.14
  *
- * Requires: jQuery 1.2.3 ~ 1.8.2
+ * Requires: jQuery 1.2.3 ~ 1.9.0
  */
-;(function(a){a.fn.extend({actual:function(b,l){if(!this[b]){throw'$.actual => The jQuery method "'+b+'" you called does not exist';}var f={absolute:false,clone:false,includeMargin:false};var i=a.extend(f,l);var e=this.eq(0);var h,j;if(i.clone===true){h=function(){var m="position: absolute !important; top: -1000 !important; ";e=e.clone().attr("style",m).appendTo("body");};j=function(){e.remove();};}else{var g=[];var d="";var c;h=function(){c=e.parents().andSelf().filter(":hidden");d+="visibility: hidden !important; display: block !important; ";if(i.absolute===true){d+="position: absolute !important; ";}c.each(function(){var m=a(this);g.push(m.attr("style"));m.attr("style",d);});};j=function(){c.each(function(m){var o=a(this);var n=g[m];if(n===undefined){o.removeAttr("style");}else{o.attr("style",n);}});};}h();var k=/(outer)/g.test(b)?e[b](i.includeMargin):e[b]();j();return k;}});})(jQuery);
+;(function(e){e.fn.extend({actual:function(t,n){if(!this[t]){throw'$.actual => The jQuery method "'+t+'" you called does not exist'}var r={absolute:false,clone:false,includeMargin:false};var i=e.extend(r,n);var s=this.eq(0);var o,u;if(i.clone===true){o=function(){var e="position: absolute !important; top: -1000 !important; ";s=s.clone().attr("style",e).appendTo("body")};u=function(){s.remove()}}else{var a=[];var f="";var l;o=function(){if(e.fn.jquery>="1.8.0")l=s.parents().addBack().filter(":hidden");else l=s.parents().andSelf().filter(":hidden");f+="visibility: hidden !important; display: block !important; ";if(i.absolute===true)f+="position: absolute !important; ";l.each(function(){var t=e(this);a.push(t.attr("style"));t.attr("style",f)})};u=function(){l.each(function(t){var n=e(this);var r=a[t];if(r===undefined){n.removeAttr("style")}else{n.attr("style",r)}})}}o();var c=/(outer)/g.test(t)?s[t](i.includeMargin):s[t]();u();return c}})})(jQuery)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"    : "actual",
-  "version" : "1.0.13",
+  "version" : "1.0.14",
   "title"   : "jQuery Actual Plugin",
   "author"  : "dreamerslab <ben@dreamerslab.com>",
   "description": "Older version of jQuery has trouble finding the width/height of invisible DOM elements. With element or its parent element has css property 'display' set to 'none'. `$('.hidden').width();` will return 0 instead of the actual width; This plugin simply fix it.",
@@ -15,7 +15,8 @@
     { "name": "Erwin Derksen" },
     { "name": "Jon Tara", "email": "jtara-github-public@spamex.com" },
     { "name": "Matt Hinchliffe", "email": "matt@maketea.co.uk" },
-    { "name": "Ryan Millikin" }
+    { "name": "Ryan Millikin" },
+    { "name": "Jacob Quant" }
   ],
   "licenses": [{
     "type"  : "MIT",


### PR DESCRIPTION
Use jQuery.fn.addBack() instead of jQuery.fn.andSelf() when using jQuery
1.8.0 or newer. Also, since the jQuery.browser feature was removed,
demo\css3pie.html now uses JavaScript's built-in navigator option to
detect MSIE version < 7.

See [issue #8][https://github.com/dreamerslab/jquery.actual/issues/8]
