### PR TITLE
Detect presence of $.fn.addBack function instead of jQuery version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jQuery Actual Plugin CHANGELOG
 
+## 1.0.15
+
+- [bug fix] Replaced jQuery version detection with feature detection. Previously this would not properly detect jQuery 1.10+
+
 ## 1.0.14
 
 - Added support for jQuery 1.9.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jQuery has trouble finding the width/height of invisible DOM elements. With elem
 
 ## Requires
 
-- jQuery 1.2.3 ~ 1.9.0
+- jQuery >= 1.2.3
 
 
 

--- a/jquery.actual.js
+++ b/jquery.actual.js
@@ -1,9 +1,9 @@
 /*! Copyright 2012, Ben Lin (http://dreamerslab.com/)
  * Licensed under the MIT License (LICENSE.txt).
  *
- * Version: 1.0.14
+ * Version: 1.0.15
  *
- * Requires: jQuery 1.2.3 ~ 1.9.0
+ * Requires: jQuery >= 1.2.3
  */
 ;( function ( $ ){
   $.fn.extend({
@@ -46,9 +46,9 @@
 
         fix = function (){
           // get all hidden parents
-          if ($.fn.jquery >= "1.8.0")
+          if (typeof $.fn.addBack === "function")
             $hidden = $target.parents().addBack().filter( ':hidden' );
-          else
+          else // if (typeof $.fn.andSelf === "function")
             $hidden = $target.parents().andSelf().filter( ':hidden' );
 
           style += 'visibility: hidden !important; display: block !important; ';

--- a/jquery.actual.min.js
+++ b/jquery.actual.min.js
@@ -1,8 +1,8 @@
 /*! Copyright 2012, Ben Lin (http://dreamerslab.com/)
  * Licensed under the MIT License (LICENSE.txt).
  *
- * Version: 1.0.14
+ * Version: 1.0.15
  *
- * Requires: jQuery 1.2.3 ~ 1.9.0
+ * Requires: jQuery >= 1.2.3
  */
-;(function(e){e.fn.extend({actual:function(t,n){if(!this[t]){throw'$.actual => The jQuery method "'+t+'" you called does not exist'}var r={absolute:false,clone:false,includeMargin:false};var i=e.extend(r,n);var s=this.eq(0);var o,u;if(i.clone===true){o=function(){var e="position: absolute !important; top: -1000 !important; ";s=s.clone().attr("style",e).appendTo("body")};u=function(){s.remove()}}else{var a=[];var f="";var l;o=function(){if(e.fn.jquery>="1.8.0")l=s.parents().addBack().filter(":hidden");else l=s.parents().andSelf().filter(":hidden");f+="visibility: hidden !important; display: block !important; ";if(i.absolute===true)f+="position: absolute !important; ";l.each(function(){var t=e(this);a.push(t.attr("style"));t.attr("style",f)})};u=function(){l.each(function(t){var n=e(this);var r=a[t];if(r===undefined){n.removeAttr("style")}else{n.attr("style",r)}})}}o();var c=/(outer)/g.test(t)?s[t](i.includeMargin):s[t]();u();return c}})})(jQuery)
+;(function(e){e.fn.extend({actual:function(t,n){if(!this[t]){throw'$.actual => The jQuery method "'+t+'" you called does not exist'}var r={absolute:false,clone:false,includeMargin:false};var i=e.extend(r,n);var s=this.eq(0);var o,u;if(i.clone===true){o=function(){var e="position: absolute !important; top: -1000 !important; ";s=s.clone().attr("style",e).appendTo("body")};u=function(){s.remove()}}else{var a=[];var f="";var l;o=function(){if(typeof e.fn.addBack==="function")l=s.parents().addBack().filter(":hidden");else l=s.parents().andSelf().filter(":hidden");f+="visibility: hidden !important; display: block !important; ";if(i.absolute===true)f+="position: absolute !important; ";l.each(function(){var t=e(this);a.push(t.attr("style"));t.attr("style",f)})};u=function(){l.each(function(t){var n=e(this);var r=a[t];if(r===undefined){n.removeAttr("style")}else{n.attr("style",r)}})}}o();var c=/(outer)/g.test(t)?s[t](i.includeMargin):s[t]();u();return c}})})(jQuery)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"    : "actual",
-  "version" : "1.0.14",
+  "version" : "1.0.15",
   "title"   : "jQuery Actual Plugin",
   "author"  : "dreamerslab <ben@dreamerslab.com>",
   "description": "Older version of jQuery has trouble finding the width/height of invisible DOM elements. With element or its parent element has css property 'display' set to 'none'. `$('.hidden').width();` will return 0 instead of the actual width; This plugin simply fix it.",


### PR DESCRIPTION
To determine whether or not the deprecated jQuery function "andSelf" should be used instead of "addBack" the code used to check if the jQuery version string was >= "1.8.0" since that is the point where the old function was deprecated. However, string comparisons will not yield the desired result when comparing numbers consisting of a different number of digits. Rather than make the version comparison more complex to compensate for this I have changed the condition to check for the presence of the newer function and use it if it is defined. This seems to better fit the spirit of "feature detection" vs "browser/framework detection"

This should correct the defect observed by kcivey here: https://github.com/dreamerslab/jquery.actual/pull/9#issuecomment-21221442
