### PR TITLE
add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "author": "dreamerslab",
+  "name": "jquery.actual",
+  "version": "1.0.15",
+  "description": "Get the actual width/height of invisible DOM elements with jQuery.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dreamerslab/jquery.actual"
+  },
+  "keywords": [
+    "jquery",
+    "actual"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.2.3"
+  },
+  "main": "jquery.actual.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
would be nice to see your plugin in the bower.io packages list :)

after merge it can to be populated with

```
bower register jquery.actual https://github.com/dreamerslab/jquery.actual.git
```
