### PR TITLE
Added meteor support

### DIFF
--- a/meteor/tests.js
+++ b/meteor/tests.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Tinytest.add('Actual integration', function (test) {
+
+    var outerElement = document.createElement('div');
+    outerElement.value = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in.";
+    outerElement.className = 'hidden';
+    outerElement.setAttribute('width', '150px');
+
+    var actual = $('.hidden').actual('width');
+    test.isNull(actual, 'instantiation OK');
+});

--- a/package.js
+++ b/package.js
@@ -1,0 +1,26 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'dreamerslab:jquery.actual'; // https://atmospherejs.com/mediatainment/switchery
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+
+Package.describe({
+    name: packageName,
+    version: '0.0.1',
+    // Brief, one-line summary of the package.
+    summary: 'Get the actual width/height of invisible DOM elements with jQuery.',
+    // URL to the Git repository containing the source code for this package.
+    git: 'https://github.com/dreamerslab/jquery.actual'
+});
+
+Package.onUse(function (api) {
+    api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+    api.use('jquery', where);
+    api.addFiles('jquery.actual.js', where);
+});
+
+Package.onTest(function (api) {
+    api.use([packageName, 'sanjo:jasmine'], where);
+    api.use(['webapp','tinytest'], where);
+    api.addFiles('meteor/tests.js', where); // testing specific files
+});


### PR DESCRIPTION
Hi,

I'm a Meteor.js dev and eager package creator for Meteor. jquery.actual is a cool library, and adding it to Meteor's ecosystem will expose it to many new devs (Meteor has 22k+ stars on GitHub), likely bringing in new testers and contributors.

This PullRequest will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

I've already published the current version of the package on Atmosphere (Meteor's package directory, you can see it here: https://atmospherejs.com/dreamerslab/jquery.actual). When you release new versions, you can publish them automatically to Atmosphere with grunt meteor.

Thanks & best regards,

Jan